### PR TITLE
Patch AWS SDK Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
 node_modules
 .idea
+

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The following environment variables can be configured:
 * `LOCALSTACK_ENDPOINT`: Sets a custom endpoint directly. Overrides `EDGE_PORT` and `LOCALSTACK_HOSTNAME` (default `https://localhost.localstack.cloud:4566`)
 
 ## Change Log
+* 0.2.5: patch AWS-SDK Config
 * 0.2.4: add missing handlers
 * 0.2.3: fix paths for patching
 * 0.2.2: command line parameters

--- a/event-handlers/handle-PreInit.js
+++ b/event-handlers/handle-PreInit.js
@@ -11,9 +11,9 @@ async function run(context, args) {
         question: 'Do you want to create the project in LocalStack? [y/N]',
         defaultValue: "n"
     });
-  }else if (inputValue == 'true'){
+  }else if (inputValue.toLowerCase() == 'true' || inputValue.toLowerCase() == 'yes'){
     doPatch = true
-  }else if (inputValue == 'false'){
+  }else if (inputValue.toLowerCase()== 'false' || inputValue.toLowerCase() == 'no'){
     doPatch = false
   }else{
     context.print.error(`ERROR: "${value}" is an invalid value for parameter --use-localstack. Please use true or false`)

--- a/event-handlers/handle-PreInit.js
+++ b/event-handlers/handle-PreInit.js
@@ -11,9 +11,9 @@ async function run(context, args) {
         question: 'Do you want to create the project in LocalStack? [y/N]',
         defaultValue: "n"
     });
-  }else if (inputValue.toLowerCase() == 'true' || inputValue.toLowerCase() == 'yes'){
+  }else if (['true', 'yes'].includes(inputValue.toLowerCase())){
     doPatch = true
-  }else if (inputValue.toLowerCase()== 'false' || inputValue.toLowerCase() == 'no'){
+  }else if (['false', 'no'].includes(inputValue.toLowerCase())){
     doPatch = false
   }else{
     context.print.error(`ERROR: "${value}" is an invalid value for parameter --use-localstack. Please use true or false`)

--- a/event-handlers/handle-PrePush.js
+++ b/event-handlers/handle-PrePush.js
@@ -10,9 +10,9 @@ async function run(context, args) {
         question: 'Do you want to create the resource in LocalStack? [y/N]',
         defaultValue: "n"
     });
-  }else if (inputValue == 'true'){
+  }else if (inputValue.toLowerCase() == 'true' || inputValue.toLowerCase() == 'yes'){
     doPatch = true
-  }else if (inputValue == 'false'){
+  }else if (inputValue.toLowerCase()== 'false' || inputValue.toLowerCase() == 'no'){
     doPatch = false
   }else{
     context.print.error(`ERROR: "${value}" is an invalid value for parameter --use-localstack. Please use true or false`)

--- a/event-handlers/handle-PrePush.js
+++ b/event-handlers/handle-PrePush.js
@@ -10,9 +10,9 @@ async function run(context, args) {
         question: 'Do you want to create the resource in LocalStack? [y/N]',
         defaultValue: "n"
     });
-  }else if (inputValue.toLowerCase() == 'true' || inputValue.toLowerCase() == 'yes'){
+  }else if (['true', 'yes'].includes(inputValue.toLowerCase())){
     doPatch = true
-  }else if (inputValue.toLowerCase()== 'false' || inputValue.toLowerCase() == 'no'){
+  }else if (['false', 'no'].includes(inputValue.toLowerCase())){
     doPatch = false
   }else{
     context.print.error(`ERROR: "${value}" is an invalid value for parameter --use-localstack. Please use true or false`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amplify-localstack",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "amplify-localstack",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "Apache 2.0",
       "dependencies": {
         "cypress": "^12.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-localstack",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/patches.js
+++ b/patches.js
@@ -83,8 +83,21 @@ const patchWriteJsonFileUtility = (context) => {
   }
 }
 
+const patchAwsSdkConfig = function(context){
+  const awsCorePath = `${snapshotPath}aws-sdk/lib/core`
+  const endpoint = getLocalEndpoint()
+
+  try {
+    const awsConfig = require(awsCorePath)
+    awsConfig.config.endpoint = endpoint
+  } catch (error) {
+    context.print.error('Error:\t\tLocalstack Plugin unable to patch AWS SDK Config', error)
+  }
+}
+
 const patchEverything = (context) => {
   context.print.info('Info:\t Patching AWS Amplify libs')
+  patchAwsSdkConfig(context)
   patchConfigManagerLoader(context)
   patchCopyBatch(context)
   patchWriteJsonFileUtility(context)

--- a/patches.js
+++ b/patches.js
@@ -83,7 +83,7 @@ const patchWriteJsonFileUtility = (context) => {
   }
 }
 
-const patchAwsSdkConfig = function(context){
+const patchAwsSdkConfig = function (context) {
   const awsCorePath = `${snapshotPath}aws-sdk/lib/core`
   const endpoint = getLocalEndpoint()
 


### PR DESCRIPTION
This PR allows the plugin to patch the AWS-SDK Configuration in runtime for the Amplify CLI. Which should allow the tool to target LocalStack for other type operations apart for initializing a project or creating resources.

PS: Also includes a change to allow `yes` or `no` as valid inputs for the `--use-localstack` parameter. Reason: It sounds more natural.