### PR TITLE
Update settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following environment variables can be configured:
 * `LOCALSTACK_ENDPOINT`: Sets a custom endpoint (default `https://localhost.localstack.cloud:4566`).
 
 ## Change Log
+* 0.3.0: more and up to date settings
 * 0.2.5: patch AWS-SDK Config
 * 0.2.4: add missing handlers
 * 0.2.3: fix paths for patching

--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ amplify push --use-localstack true
 ### Configuration
 The following environment variables can be configured:
 
-* `EDGE_PORT`: Port under which LocalStack edge service is accessible (default: `4566`)
-* `LOCALSTACK_HOSTNAME`: Target host under which LocalStack edge service is accessible (default: `localhost.localstack.cloud`)
-* `LOCALSTACK_ENDPOINT`: Sets a custom endpoint directly. Overrides `EDGE_PORT` and `LOCALSTACK_HOSTNAME` (default `https://localhost.localstack.cloud:4566`)
+* `LOCALSTACK_ACCESS_KEY_ID`: Sets custom Access Key Id for the internal client to use (default `test`).
+* `LOCALSTACK_ACCESS_KEY_SECRET`: Sets custom Access Key Secret for the internal client to use (default `test`).
+* `LOCALSTACK_REGION`: Sets a custom region (default `us-east-1`).
+* `LOCALSTACK_S3_FORCE_PATH_STYLE`: Sets the S3 path style (default `1`, accepted values: `1`as true and `0` as false)).
+* `LOCALSTACK_ENDPOINT`: Sets a custom endpoint (default `https://localhost.localstack.cloud:4566`).
 
 ## Change Log
 * 0.2.5: patch AWS-SDK Config

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amplify-localstack",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "amplify-localstack",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "license": "Apache 2.0",
       "dependencies": {
         "cypress": "^12.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-localstack",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/patches.js
+++ b/patches.js
@@ -11,9 +11,7 @@ const AWS_DEFAULT_REGION = 'us-east-1'
 // const snapshotPath = '/snapshot/repo/build/node_modules/'
 const snapshotPath = '/snapshot/amplify-cli/build/node_modules/'
 const getLocalEndpoint = () => {
-  const port = process.env.EDGE_PORT || DEFAULT_EDGE_PORT
-  const host = process.env.LOCALSTACK_HOSTNAME || DEFAULT_HOSTNAME
-  return process.env.LOCALSTACK_ENDPOINT || `https://${host}:${port}`
+  return process.env.LOCALSTACK_ENDPOINT || `https://${DEFAULT_HOSTNAME}:${DEFAULT_EDGE_PORT}`
 }
 
 // Patchs the awscloudformation provider plugin to deploy the resources into LocalStack
@@ -25,10 +23,10 @@ const patchConfigManagerLoader = (context) => {
     sysConfigManager.loadConfiguration = () => {
       const config = {}
       config.endpoint = getLocalEndpoint()
-      config.accessKeyId = AWS_ACCESS_KEY_ID
-      config.secretAccessKey = AWS_SECRET_ACCESS_KEY
-      config.s3ForcePathStyle = true
-      config.region = AWS_DEFAULT_REGION
+      config.accessKeyId = process.env.LOCALSTACK_ACCESS_KEY_ID || AWS_ACCESS_KEY_ID
+      config.secretAccessKey = process.env.LOCALSTACK_ACCESS_KEY_SECRET || AWS_SECRET_ACCESS_KEY
+      config.s3ForcePathStyle = process.env.LOCALSTACK_S3_FORCE_PATH_STYLE !== '0'
+      config.region = process.env.LOCALSTACK_REGION || AWS_DEFAULT_REGION
       return config
     }
   } catch (error) {


### PR DESCRIPTION
This PR add more options to config and removes the old way of setting port and endpoint in different variables. This way is more inline with the current way of setting the endpoint in LocalStack