### PR TITLE
Fix principal rewriting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,53 +23,58 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '18'
       - name: Build and Lint
         run: |
           npm install
           npm run lint
+      - name: Install AWS CLI
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install awscli
+      - name: Configure AWS credentials
+        run: |
+          aws configure set aws_access_key_id "AKIAI44QH8DHBEXAMPLE" --profile default
+          aws configure set aws_secret_access_key "je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY" --profile default 
+          aws configure set region "us-east-1" --profile default
+          aws configure set output "json" --profile default
       - name: Install Amplify CLI
         run: npm install -g @aws-amplify/cli
       - name: Set up Amplify Plugin
         run: |
           npm -g install .
           amplify plugin scan
-      - name: Configure Amplify CLI
-        run: |
-          aws configure set aws_access_key_id "AKIAI44QH8DHBEXAMPLE" --profile default
-          aws configure set aws_secret_access_key "je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY" --profile default 
-          aws configure set region "us-east-1" --profile default
-          aws configure set output "json" --profile default
       - name: Install Localstack
         run: pip install localstack
       - name: Start and wait for localstack
         timeout-minutes: 5
         run: |
-          docker pull localstack/localstack:latest
-          LOCALSTACK_API_KEY=${{ secrets.LOCALSTACK_API_KEY }} localstack start -d 
+          docker pull localstack/localstack-pro:latest
+          LOCALSTACK_API_KEY=${{ secrets.LOCALSTACK_API_KEY }} DEBUG=1 localstack start -d 
           localstack wait -t 30
-      
+
       - name: Init Amplify Project
         run: |
           mkdir test_project
           cd test_project
           amplify init --envName test --yes --use-localstack true
-      
+
       - name: Add Auth Resource
         working-directory: test_project
         run: |
           cat ../headlessRequests/addAuth.json | jq -c | amplify add auth --headless 
-      
+
       - name: Add Storage Resource
         working-directory: test_project
         run: |
           cat ../headlessRequests/addStorage.json | jq -c | amplify add storage --headless 
-      
+
       - name: Add Api Resource
         working-directory: test_project
         run: |
           cat ../headlessRequests/addApi.json | jq -c | amplify add api --headless 
-      
+
       - name: Push Resources
         working-directory: test_project
         run: amplify push --use-localstack true --yes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release NPM Package
+
+on:
+  push:
+    branches:
+      - main  # Change this to your default branch
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 'lts/*'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following environment variables can be configured:
 * `LOCALSTACK_ENDPOINT`: Sets a custom endpoint (default `https://localhost.localstack.cloud:4566`).
 
 ## Change Log
+* 0.2.7: remove patching of CFn files
 * 0.2.6: more and up to date settings
 * 0.2.5: patch AWS-SDK Config
 * 0.2.4: add missing handlers

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.2.6",
       "license": "Apache 2.0",
       "dependencies": {
+        "amplify-localstack": "github:localstack/amplify-localstack#fix-principal-rewriting",
         "cypress": "^12.9.0",
         "yesno": "^0.4.0"
       },
@@ -275,6 +276,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/amplify-localstack": {
+      "version": "0.2.6",
+      "resolved": "git+ssh://git@github.com/localstack/amplify-localstack.git#97eb5e8864f00c3b4b32598257266df05e748345",
+      "license": "Apache 2.0",
+      "dependencies": {
+        "cypress": "^12.9.0",
+        "yesno": "^0.4.0"
       }
     },
     "node_modules/ansi-colors": {
@@ -3793,6 +3803,14 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
+      }
+    },
+    "amplify-localstack": {
+      "version": "git+ssh://git@github.com/localstack/amplify-localstack.git#97eb5e8864f00c3b4b32598257266df05e748345",
+      "from": "amplify-localstack@github:localstack/amplify-localstack#fix-principal-rewriting",
+      "requires": {
+        "cypress": "^12.9.0",
+        "yesno": "^0.4.0"
       }
     },
     "ansi-colors": {

--- a/patches.js
+++ b/patches.js
@@ -72,7 +72,6 @@ const patchEverything = (context) => {
   context.print.info('Info:\t Patching AWS Amplify libs')
   patchAwsSdkConfig(context)
   patchConfigManagerLoader(context)
-  // patchCopyBatch(context)
   patchWriteJsonFileUtility(context)
 }
 

--- a/patches.js
+++ b/patches.js
@@ -1,4 +1,4 @@
-const fs = require('fs')
+// const fs = require('fs')
 
 const DEFAULT_EDGE_PORT = 4566
 const DEFAULT_HOSTNAME = 'localhost.localstack.cloud'
@@ -35,32 +35,33 @@ const patchConfigManagerLoader = (context) => {
 }
 
 // Patchs the utility that copy files from .ejs to replace the hardcoded AWS domains with LocalStack domains
-const patchCopyBatch = (context) => {
-  const newDomain = getLocalEndpoint().replace('https://', '').replace('http://', '')
-  const port = newDomain.split(':').pop()
-  const copyBatchPath = `${snapshotPath}@aws-amplify/cli-internal/lib/extensions/amplify-helpers/copy-batch`
-
-  try {
-    const copyBatchLib = require(copyBatchPath)
-    const oldMethod = copyBatchLib.copyBatch
-    copyBatchLib.copyBatch = async (context, jobs, props, force, writeParams) => {
-      await oldMethod(context, jobs, props, force, writeParams)
-
-      //
-      jobs.forEach(job => {
-        // console.log(`LS Plugin is patching file: ${job.template}`)
-        const file = job.target
-        const content = fs.readFileSync(file).toString()
-        const newContent = content.replace(new RegExp(`amazonaws.com(:${port})?`, 'gm'), newDomain)
-        fs.writeFileSync(file, newContent)
-      })
-    }
-  } catch (error) {
-    context.print.error('Error:\t\tLocalStack Plugin unable to patch CopyBatch Utility', error)
-  }
-}
+// const patchCopyBatch = (context) => {
+//   const newDomain = getLocalEndpoint().replace('https://', '').replace('http://', '')
+//   const port = newDomain.split(':').pop()
+//   const copyBatchPath = `${snapshotPath}@aws-amplify/cli-internal/lib/extensions/amplify-helpers/copy-batch`
+//
+//   try {
+//     const copyBatchLib = require(copyBatchPath)
+//     const oldMethod = copyBatchLib.copyBatch
+//     copyBatchLib.copyBatch = async (context, jobs, props, force, writeParams) => {
+//       await oldMethod(context, jobs, props, force, writeParams)
+//
+//       //
+//       jobs.forEach(job => {
+//         // console.log(`LS Plugin is patching file: ${job.template}`)
+//         const file = job.target
+//         const content = fs.readFileSync(file).toString()
+//         const newContent = content.replace(new RegExp(`amazonaws.com(:${port})?`, 'gm'), newDomain)
+//         fs.writeFileSync(file, newContent)
+//       })
+//     }
+//   } catch (error) {
+//     context.print.error('Error:\t\tLocalStack Plugin unable to patch CopyBatch Utility', error)
+//   }
+// }
 
 // Patchs the utility that generates json files replacing the hardcoded AWS domains with LocalStack domains
+// These EJS tend to be AWS Cloudformation JSON templates
 const patchWriteJsonFileUtility = (context) => {
   const jsonUtilitiesPath = `${snapshotPath}@aws-amplify/amplify-cli-core/lib/jsonUtilities`
   const newDomain = getLocalEndpoint().replace('https://', '').replace('http://', '')
@@ -97,7 +98,7 @@ const patchEverything = (context) => {
   context.print.info('Info:\t Patching AWS Amplify libs')
   patchAwsSdkConfig(context)
   patchConfigManagerLoader(context)
-  patchCopyBatch(context)
+  // patchCopyBatch(context)
   patchWriteJsonFileUtility(context)
 }
 

--- a/patches.js
+++ b/patches.js
@@ -34,32 +34,6 @@ const patchConfigManagerLoader = (context) => {
   }
 }
 
-// Patchs the utility that copy files from .ejs to replace the hardcoded AWS domains with LocalStack domains
-// const patchCopyBatch = (context) => {
-//   const newDomain = getLocalEndpoint().replace('https://', '').replace('http://', '')
-//   const port = newDomain.split(':').pop()
-//   const copyBatchPath = `${snapshotPath}@aws-amplify/cli-internal/lib/extensions/amplify-helpers/copy-batch`
-//
-//   try {
-//     const copyBatchLib = require(copyBatchPath)
-//     const oldMethod = copyBatchLib.copyBatch
-//     copyBatchLib.copyBatch = async (context, jobs, props, force, writeParams) => {
-//       await oldMethod(context, jobs, props, force, writeParams)
-//
-//       //
-//       jobs.forEach(job => {
-//         // console.log(`LS Plugin is patching file: ${job.template}`)
-//         const file = job.target
-//         const content = fs.readFileSync(file).toString()
-//         const newContent = content.replace(new RegExp(`amazonaws.com(:${port})?`, 'gm'), newDomain)
-//         fs.writeFileSync(file, newContent)
-//       })
-//     }
-//   } catch (error) {
-//     context.print.error('Error:\t\tLocalStack Plugin unable to patch CopyBatch Utility', error)
-//   }
-// }
-
 // Patchs the utility that generates json files replacing the hardcoded AWS domains with LocalStack domains
 // These EJS tend to be AWS Cloudformation JSON templates
 const patchWriteJsonFileUtility = (context) => {


### PR DESCRIPTION
## Motivation
This PR removes the function `patchCopyBatch` because it replaces the `amazonaws.com` even in IAM policies. This will generate that some cluodformation stack outputs don't have the correct endpoints but it's minimal compare to the damage it does to IAM policies. 

## Changes
- removing of function
- extending ci action to include the installation of awscli
- new gh actio to auto-publish npm package
