### PR TITLE
Skip principal in endpoint patching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,5 @@
 name: CI
 on:
-  push:
-    paths-ignore:
-      - 'README.md'
-    branches:
-      - main
   pull_request:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The following environment variables can be configured:
 * `LOCALSTACK_ENDPOINT`: Sets a custom endpoint (default `https://localhost.localstack.cloud:4566`).
 
 ## Change Log
+* 0.2.8: skip patching of endpoints for Statement Principals
 * 0.2.7: remove patching of CFn files
 * 0.2.6: more and up to date settings
 * 0.2.5: patch AWS-SDK Config

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amplify-localstack",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "amplify-localstack",
-      "version": "0.2.6",
+      "version": "0.2.8",
       "license": "Apache 2.0",
       "dependencies": {
         "amplify-localstack": "github:localstack/amplify-localstack#fix-principal-rewriting",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "amplify-localstack",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR makes sure to skip the transforming of endpoints under a Principal Attribute. Due to being necessary for IAM.